### PR TITLE
Fix bug that checksum will fail when buffer is not fully used.

### DIFF
--- a/JavaForTianlin/src/org/tianlin/java/exercise6/game/GameClient.java
+++ b/JavaForTianlin/src/org/tianlin/java/exercise6/game/GameClient.java
@@ -19,6 +19,7 @@ public class GameClient {
 	private static final int SERVER_PORT = 30001;
 	private static final int BUFFER_LENGTH = 32; // TODO is it too small?
 
+	// TODO change buffer to below buffer in encoding methods
 	private byte[] buffer = new byte[BUFFER_LENGTH];
 	/*
 	 * menu list
@@ -150,7 +151,7 @@ public class GameClient {
 		DecodeResult result = CoDec.decode(buffer, length);
 		boolean response = result.valid && (boolean) result.arguments[0];
 		p("Authentication %s!\n", response ? "succeed" : "fail");
-		return true;
+		return response;
 	}
 
 	private void sendClientExit(DataOutputStream output) throws IOException {

--- a/JavaForTianlin/src/org/tianlin/java/exercise6/game/utility/CoDec.java
+++ b/JavaForTianlin/src/org/tianlin/java/exercise6/game/utility/CoDec.java
@@ -24,7 +24,15 @@ public class CoDec {
 			return new DecodeResult();
 		}
 
-		if (!verifyChecksum(bytes)) {
+		if (DEBUG) {
+			StringBuilder builder = new StringBuilder();
+			for (int i = 0; i < length; i++) {
+				builder.append(String.format("0x%02X, ", bytes[i]));
+			}
+			Log.d(TAG, "Decode command { %s }", builder.substring(0, builder.length() - 2));
+		}
+
+		if (!verifyChecksum(bytes, length)) {
 			Log.w(TAG, "Checksum failure when decoding.");
 			return new DecodeResult();
 		}
@@ -223,10 +231,10 @@ public class CoDec {
 	/*
 	 * verify checksum
 	 */
-	private static boolean verifyChecksum(byte[] b) {
+	private static boolean verifyChecksum(byte[] b, int length) {
 		byte c = 0;
-		for (byte b2 : b) {
-			c ^= b2;
+		for (int i = 0; i < length; i++) {
+			c ^= b[i];
 		}
 		return c == 0;
 	}


### PR DESCRIPTION
1. Add debug info in decoding method
2. Change login method's return value to be same as authentication
   result
